### PR TITLE
Typo in main.nf: params.fastq_r1 default defined twice

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -16,7 +16,7 @@ the cache? Or will all samples run from the start?
 params.fastq_csv = null
 params.sample = null
 params.fastq_r1 = null
-params.fastq_r1 = null
+params.fastq_r2 = null
 params.reference = null
 params.targets = null
 params.whitelist = null


### PR DESCRIPTION
There was a typo in `main.nf` such that `params.fastq_r1` was defined twice, but `params.fastq_r2` was not defined at all. This had little impact in reality, it just meant that `params.fastq_r1` was not defined as `null` by default. This is now fixed.