### PR TITLE
Containerize the pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM nfcore/base:latest
 
 LABEL \
     authors="olavur@fargen.fo" \
-    description="Image with tools used in exolink" \
+    description="LinkSeq -- GATK best-practices pipeline adapted to linked-reads [WIP]" \
     maintainer="Ólavur Mortensen <olavur@fargen.fo>"
 
-RUN apt update -yqq && \
-    apt install -yqq \
+RUN apt-get update -yqq && \
+    apt-get install -yqq \
     unzip \
     ttf-dejavu
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH /opt/conda/envs/exolink-alpha/bin:$PATH
+ENV PATH /opt/conda/envs/linkseq/bin:$PATH

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,9 @@ name: linkseq
 
 channels:
   - bioconda
+  - conda-forge
   - defaults
   - AgBiome
-
-# NOTE: conda-forge is needed for multiqc v1.8, but in some bizarre way, conda-forge breaks my Nextflow
-# installation, such that processes are not submitted in parallel properly.
 
 dependencies:
   - nextflow=20.01.0
@@ -23,5 +21,5 @@ dependencies:
   - hapcut2=1.2
   - whatshap=0.18
   - qualimap=2.2.2a
-  #- multiqc=1.8
+  - multiqc=1.8
   - snpeff=4.3.1t


### PR DESCRIPTION
The `Dockerfile` is now built on DockerHub (https://hub.docker.com/r/olavurmortensen/linkseq). I updated the `Dockerfile` and the conda `environment.yml`, and tested running the pipeline on the FarGen cluster using Kubernetes.