### PR TITLE
Updated interval BED help

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,20 @@ The `reference/gatk_bundle.sh` script downloads all the resources needed from th
 > GATK resource bundle
 > https://console.cloud.google.com/storage/browser/genomics-public-data/resources/broad/hg38/v0
 
-### Exome sequencing targets
+### Interval BED file
 
-Our particular sequencing experiment uses the Agilent SureSelect Human All Exon V6 UTR kit to capture the exome. `reference/sureselect_human_all_exon_v6_utr_grch38` contains the target BED file we use and some details are in the README.
+You should always use an interval BED file when running this pipeline. If you're running whole-genome sequencing, you might want to use WGS calling regions such as those from the GATK Resource Bundle:
+
+> GATK Resource Bundle
+>
+> https://gatk.broadinstitute.org/hc/en-us/articles/360035890811-Resource-bundle
+
+Specifically this file:
+
+> WGS calling regions hg38
+>
+> https://storage.cloud.google.com/genomics-public-data/resources/broad/hg38/v0/wgs_calling_regions.hg38.interval_list
+
+Our particular sequencing experiment uses the Agilent SureSelect Human All Exon V6 UTR kit to capture the exome. The folder `reference/sureselect_human_all_exon_v6_utr_grch38` contains an **example BED file**, and a `README` that explains where this file comes from. If `LinkSeq` is unwilling to accept your BED file, this example may help debug the problem.
 
 

--- a/reference/sureselect_human_all_exon_v6_utr_grch38/README
+++ b/reference/sureselect_human_all_exon_v6_utr_grch38/README
@@ -1,7 +1,13 @@
+The example.bed file contains a few lines of the interval BED file used in the development of this pipeline.
 
-Obtained from:
+The original file was obtained from:
 https://earray.chem.agilent.com/suredesign/search.htm
 
 Search for "SureSelect Human All Exon V6 UTR" in Agilent Catalog. Choose hg38.
 
-The file S07604624_Padded.bed has been edited so that the first line ("#browser position chr1:11981-12351") is commented out with a "#", because not all BED readers correctly skip this line. If other files are used, this can be done as well.
+We took the S07604624_Padded.bed file and modified it using the following command:
+
+awk 'BEGIN{OFS="\t"}{ if(NR <= 2) { print "#"$0 } else { print $1,$2,$3,$4,0,"." } }' S07604624_Padded.bed > S07604624_Padded_modified.bed
+
+First, the header of the file (the two first lines) are commented out with a "#", because not all BED readers correctly skip these lines. Second, two "empty" columns have been added to the rows in the file, as some programs require the file to have 6 fields, regardless whether these are empty.
+

--- a/reference/sureselect_human_all_exon_v6_utr_grch38/example.bed
+++ b/reference/sureselect_human_all_exon_v6_utr_grch38/example.bed
@@ -1,0 +1,18 @@
+#browser position chr1:11981-12351
+#track name="Padded" description="Agilent SureSelect DNA - SureSelect Human All Exon V6+UTR - Covered bed file extended by 100bp on either side" color=0,0,128 db=hg38
+chr1    11980   12351   ref|DDX11L1,ref|NR_046018,ens|ENST00000456328,ens|ENST00000450305       0       .
+chr1    12495   12902   ref|DDX11L1,ref|NR_046018,ens|ENST00000456328,ens|ENST00000450305       0       .
+chr1    13063   13758   ref|DDX11L1,ref|NR_046018,ens|ENST00000456328,ens|ENST00000450305       0       .
+chr1    14520   15115   ref|WASH7P,ref|NR_024540,ens|ENST00000488147    0       .
+chr1    15695   16014   ref|WASH7P,ref|NR_024540,ens|ENST00000488147    0       .
+chr1    16643   17198   ref|WASH7P,ref|NR_024540,ens|ENST00000488147    0       .
+chr1    17147   18221   ref|WASH7P,ref|NR_024540,ens|ENST00000488147,miRNA|hsa-miR-6859-5p,miRNA|hsa-miR-6859-3p        0       .
+chr1    18116   18511   ref|WASH7P,ref|NR_024540,ens|ENST00000488147    0       .
+chr1    18863   19269   ref|WASH7P,ref|NR_024540,ens|ENST00000488147    0       .
+chr1    24160   24632   ref|WASH7P,ref|NR_024540,ens|ENST00000488147    0       .
+chr1    24555   24955   ref|WASH7P,ref|NR_024540,ens|ENST00000488147    0       .
+chr1    30213   30642   ens|ENST00000469289,ens|ENST00000473358,miRNA|hsa-miR-1302      0       .
+chr1    35020   35592   ref|FAM138F,ref|FAM138C,ref|FAM138A,ref|NR_026818,ref|NR_026822,ref|NR_026820,ens|ENST00000417324,ens|ENST00000461467   0       .
+chr1    35465   35879   ref|FAM138F,ref|FAM138C,ref|FAM138A,ref|NR_026818,ref|NR_026822,ref|NR_026820,ens|ENST00000417324,ens|ENST00000461467   0       .
+chr1    65409   65826   -       0       .
+chr1    65676   66072   -       0       .


### PR DESCRIPTION
The exome sequencing target file was huge, so this was removed. Instead, an example file is used. This example file is not identical to the previous however. Improved `README.md` and `reference/sureselect_human_all_exon_v6_utr_grch38/README` for better reproducibility.