### PR TITLE
HapCUT2 update

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,14 +11,14 @@ dependencies:
   - nextflow=20.01.0
   - ema=0.6.2
   - bwa=0.7.17
-  - samtools=1.9
+  - samtools=1.10
   - bbtools=37.62
   - gatk4=4.1.0.0
   - r-gsalib=2.1
   - r-gplots=3.0.1.1
   - r-ggplot2=3.1.0
   - bxtools=0.1.0
-  - hapcut2=1.2
+  - hapcut2=1.3
   - whatshap=0.18
   - fastqc=0.11.8
   - qualimap=2.2.2a


### PR DESCRIPTION
HapCUT2 v1.2 had a sporadic error, discussed here:

https://github.com/vibansal/HapCUT2/issues/77#

This was fixed in v1.3. 

Updated HapCUT2 from v1.2 to v1.3, and to avoid package conflicts also updated samtools from v1.9 to v1.10.

No changes were made in HapCUT2 from v1.2 to v1.3 that have any significant effect on LinkSeq (https://github.com/vibansal/HapCUT2/releases).

In samtools from v1.9 to v1.10 there was one change that has some change to LinkSeq (see: https://github.com/samtools/samtools/releases/tag/1.10):

> samtools sub-commands will now add @PG header lines to output sam/bam/cram files. To disable this, use the --no-PG option. (#1087; #1097)

The BAM files produced in LinkSeq already had `@PG` headers, so this should not have an effect on LinkSeq.

